### PR TITLE
mali450-userland-drm: fix INSANE_SKIP_${PN}

### DIFF
--- a/recipes-graphics/mali-userland/mali450-userland-drm_binary.bb
+++ b/recipes-graphics/mali-userland/mali450-userland-drm_binary.bb
@@ -75,5 +75,5 @@ python __anonymous() {
         d.appendVar("RCONFLICTS_" + fullp, pkgs)
 }
 
-INSANE_SKIP_${PN} = "ldflags"
+INSANE_SKIP_${PN} += "ldflags"
 


### PR DESCRIPTION
Commit b851bb441973 has added an assignment to INSANE_SKIP_${PN}, but
in the recipe this variable had been already set. So it should be "+="
instead of the "=".

Signed-off-by: Andrey Konovalov andrey.konovalov@linaro.org
